### PR TITLE
mod: build後に更に上書きしてしまう為volume mountの削除

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,1 +1,5 @@
 **/node_modules
+.git
+.dockerignore
+Dockerfile
+npm-debug.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,4 +9,4 @@ RUN npm install
 
 EXPOSE 3000
 
-CMD ["npm", "run", "start::dev"]
+CMD ["npm", "run", "start:dev"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,4 +9,4 @@ RUN npm install
 
 EXPOSE 3000
 
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "start::dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,20 +4,26 @@ services:
   frontend:
     build:
       context: ./frontend
-    tty: true
-    volumes:
-      - ./frontend:/frontend
+    # tty: true
+    # volumes:
+    #   - ./frontend:/frontend
     ports:
       - "3000:3000"
+    networks:
+      - ft_transcendence
   
   # Backend - NestJS service
   backend:
     build:
       context: ./backend
-    volumes:
-      - ./backend:/backend
+    # volumes:
+    #   - ./backend:/backend
     ports:
       - "3001:3000"
+    networks:
+      - ft_transcendence
+    depends_on:
+      - database
 
   # Database - PostgreSQL service
   database:
@@ -30,6 +36,12 @@ services:
       POSTGRES_DB: ts_database
     volumes:
       - pgdata:/var/lib/postgresql/data
+    networks:
+      - ft_transcendence
+
+networks:
+  ft_transcendence:
+    driver: bridge
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,9 @@ services:
     build:
       context: ./frontend
     # tty: true
-    # volumes:
-    #   - ./frontend:/frontend
+    volumes:
+      - ./frontend:/frontend
+      - nextjs-node-modules:/frontend/node_modules
     ports:
       - "3000:3000"
     networks:
@@ -16,8 +17,9 @@ services:
   backend:
     build:
       context: ./backend
-    # volumes:
-    #   - ./backend:/backend
+    volumes:
+      - ./backend:/backend
+      - nestjs-node-modules:/backend/node_modules
     ports:
       - "3001:3000"
     networks:
@@ -45,3 +47,5 @@ networks:
 
 volumes:
   pgdata:
+  nestjs-node-modules:
+  nextjs-node-modules:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,1 +1,5 @@
 **/node_modules
+.git
+.dockerignore
+Dockerfile
+npm-debug.log


### PR DESCRIPTION
Fixed #16 

・docker-compose.ymlでvolumeマウントをすると、ビルド時に COPY . . と npm install を実行することで、依存関係が node_modules ディレクトリにインストールされる。ボリュームマウントを使用している場合、ローカルの node_modules ディレクトリがコンテナ内のディレクトリを上書きされてしまう。

・docker networkの追加

・backend containerにdatabaseの依存関係の追加

・.dockerignoreの追加