### PR TITLE
add: フロントに共通ヘッダー・フッターを追加

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -12,3 +12,5 @@ POSTGRESS_USER=ts_user
 POSTGRESS_PASSWORD=ts_password
 POSTGRESS_DB=ts_database
 
+## アップロードディレクトリ
+AVATAR_IMAGE_DIR='uploads/'

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,8 +1,10 @@
-/* eslint-disable */
-import type { Metadata } from 'next'
-import './globals.css'
-import { LoginUserProvider } from '@/providers/useAuth'
-import { AccessControlProvider } from '@/providers/useAccessControl'
+import type { Metadata } from 'next';
+import './globals.css';
+import { LoginUserProvider } from '@/providers/useAuth';
+import { AccessControlProvider } from '@/providers/useAccessControl';
+import GlobalHeader from '@/components/common/header/globalHeader';
+import GlobalThemeProvider from '@/providers/globalThemeProvider';
+import GlobalFooter from '@/components/common/footer/globalFooter';
 
 export const metadata: Metadata = {
   title: 'ft_transcendence',
@@ -12,15 +14,19 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
-    <LoginUserProvider>
-      <AccessControlProvider>
-        <html lang="en">
-          <body>
-            {children}
-          </body>
-        </html>
-      </AccessControlProvider>
-    </LoginUserProvider>
+      <GlobalThemeProvider>
+        <LoginUserProvider>
+          <AccessControlProvider>
+            <html lang="en">
+              <body>
+                <GlobalHeader />
+                <main>{children}</main>
+                <GlobalFooter />
+              </body>
+            </html>
+          </AccessControlProvider>
+        </LoginUserProvider>
+      </GlobalThemeProvider>
     </>
-  )
+  );
 }

--- a/frontend/src/components/common/footer/globalFooter.tsx
+++ b/frontend/src/components/common/footer/globalFooter.tsx
@@ -1,0 +1,26 @@
+import { AppBar, Box, Container, Typography } from '@mui/material';
+
+const GlobalFooter = () => {
+  return (
+    <>
+      <AppBar
+        component="footer"
+        position="fixed"
+        sx={{
+          backgroundColor: 'primary',
+          top: 'auto',
+          bottom: 0,
+          width: '100%',
+        }}
+      >
+        <Container maxWidth="md">
+          <Box sx={{ textAlign: 'center' }}>
+            <Typography variant="caption">©2024 42 Tokyo</Typography>
+          </Box>
+        </Container>
+      </AppBar>
+    </>
+  );
+};
+
+export default GlobalFooter;

--- a/frontend/src/components/common/header/globalHeader.tsx
+++ b/frontend/src/components/common/header/globalHeader.tsx
@@ -1,0 +1,28 @@
+import { AppBar, Box, Link, Toolbar } from '@mui/material';
+
+const GlobalHeader = () => {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <AppBar
+        position="fixed"
+        sx={{
+          backgroundColor: 'primary',
+          top: 0,
+          width: '100%',
+        }}
+      >
+        <Toolbar>
+          <Link
+            href="/"
+            color="secondary"
+            variant="h6"
+          >
+            Ping-Pong!
+          </Link>
+        </Toolbar>
+      </AppBar>
+    </Box>
+  );
+};
+
+export default GlobalHeader;

--- a/frontend/src/providers/globalThemeProvider.tsx
+++ b/frontend/src/providers/globalThemeProvider.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { ReactNode } from 'react';
+
+/**
+ * 配色やスタイルを定義する場合はここに記述する
+ */
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#00babc', // 青
+    },
+    secondary: {
+      main: '#ffffff', // 白
+    },
+    text: {
+      primary: '#333', // 黒
+      secondary: '#666',
+    },
+    background: {
+      default: '#18181d',
+      paper: '#f5f5f5',
+    },
+  },
+  typography: {
+    fontFamily: 'Roboto, sans-serif',
+    h1: {
+      fontSize: '2.5rem',
+    },
+    h2: {
+      fontSize: '2rem',
+    },
+  },
+});
+
+/**
+ * サイト全体で使用するグローバルテーマ
+ */
+const GlobalThemeProvider = ({ children }: { children: ReactNode }) => {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+};
+
+export default GlobalThemeProvider;


### PR DESCRIPTION
グローバルヘッダー・フッターを追加しました

<img width="959" alt="add-header" src="https://github.com/tmuramat081/42_ft_transcendence/assets/91453112/3635af98-6f01-49c7-a78c-f3eae74af70a">
