### PR TITLE
add: ソケットの実体をグローバルで保持する

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { AccessControlProvider } from '@/providers/useAccessControl';
 import GlobalHeader from '@/components/common/header/globalHeader';
 import GlobalThemeProvider from '@/providers/globalThemeProvider';
 import GlobalFooter from '@/components/common/footer/globalFooter';
+import { WebSocketProvider } from '@/providers/webSocketProvider';
 
 export const metadata: Metadata = {
   title: 'ft_transcendence',
@@ -17,13 +18,15 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <GlobalThemeProvider>
         <LoginUserProvider>
           <AccessControlProvider>
-            <html lang="en">
-              <body>
-                <GlobalHeader />
-                <main>{children}</main>
-                <GlobalFooter />
-              </body>
-            </html>
+            <WebSocketProvider>
+              <html lang="en">
+                <body>
+                  <GlobalHeader />
+                  <main>{children}</main>
+                  <GlobalFooter />
+                </body>
+              </html>
+            </WebSocketProvider>
           </AccessControlProvider>
         </LoginUserProvider>
       </GlobalThemeProvider>

--- a/frontend/src/components/common/header/globalHeader.tsx
+++ b/frontend/src/components/common/header/globalHeader.tsx
@@ -1,6 +1,30 @@
+'use client';
+import { SOCKET_EVENTS } from '@/constants/socket.constant';
+import { useWebSocket } from '@/providers/webSocketProvider';
 import { AppBar, Box, Link, Toolbar } from '@mui/material';
+import { useEffect, useState } from 'react';
 
 const GlobalHeader = () => {
+  const { socket } = useWebSocket();
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    socket.on(SOCKET_EVENTS.COMMON.CONNECT, () => {
+      setIsConnected(true);
+    });
+
+    socket.on(SOCKET_EVENTS.COMMON.DISCONNECT, () => {
+      setIsConnected(false);
+    });
+
+    return () => {
+      socket.off(SOCKET_EVENTS.COMMON.CONNECT);
+      socket.off(SOCKET_EVENTS.COMMON.DISCONNECT);
+    };
+  });
+
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar
@@ -19,6 +43,7 @@ const GlobalHeader = () => {
           >
             Ping-Pong!
           </Link>
+          {isConnected && <span style={{ marginLeft: 'auto' }}>connected</span>}
         </Toolbar>
       </AppBar>
     </Box>

--- a/frontend/src/components/game/room/gameRoom.tsx
+++ b/frontend/src/components/game/room/gameRoom.tsx
@@ -4,6 +4,7 @@ import GameLog from './gameLog';
 import { Button } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import UseGameConnection from './hooks/useGameRoomConnect';
+import { useWebSocket } from '@/providers/webSocketProvider';
 
 type Props = {
   roomId: number;
@@ -16,9 +17,11 @@ type Props = {
 export default function GameRoom({ roomId, userId }: Props) {
   // ルーティング
   const router = useRouter();
+  // ソケット情報
+  const { socket } = useWebSocket();
 
   // ゲーム接続情報のフック
-  const { gameStarted, users, logs } = UseGameConnection({ roomId, userId });
+  const { gameStarted, users, logs } = UseGameConnection({ roomId, userId, socket });
 
   return (
     <>

--- a/frontend/src/components/game/room/hooks/useGameRoomConnect.ts
+++ b/frontend/src/components/game/room/hooks/useGameRoomConnect.ts
@@ -1,7 +1,7 @@
 'use client';
 import { SOCKET_EVENTS } from '@/constants/socket.constant';
 import { useEffect, useState } from 'react';
-import { Socket } from 'socket.io-client/debug';
+import { Socket } from 'socket.io-client';
 
 type Props = {
   roomId: number;

--- a/frontend/src/components/game/room/hooks/useGameRoomConnect.ts
+++ b/frontend/src/components/game/room/hooks/useGameRoomConnect.ts
@@ -1,13 +1,12 @@
 'use client';
 import { SOCKET_EVENTS } from '@/constants/socket.constant';
 import { useEffect, useState } from 'react';
-import { io } from 'socket.io-client';
-
-const WEBSOCKET_URL = 'http://localhost:3001';
+import { Socket } from 'socket.io-client/debug';
 
 type Props = {
   roomId: number;
   userId: number;
+  socket: Socket | null;
 };
 
 type UseGameConnectionReturnType = {
@@ -16,7 +15,11 @@ type UseGameConnectionReturnType = {
   logs: string[]; // 接続ログ
 };
 
-export const UseGameConnection = ({ roomId, userId }: Props): UseGameConnectionReturnType => {
+export const UseGameConnection = ({
+  roomId,
+  userId,
+  socket,
+}: Props): UseGameConnectionReturnType => {
   // ゲーム開始フラグ
   const [gameStarted, setGameStarted] = useState(false);
   // 接続ユーザー名
@@ -32,8 +35,7 @@ export const UseGameConnection = ({ roomId, userId }: Props): UseGameConnectionR
   };
 
   useEffect(() => {
-    // TODO: 外部から受け渡せるようにする
-    const socket = io(WEBSOCKET_URL);
+    if (!socket) return;
 
     // サーバー接続・ルーム入室
     socket.on(SOCKET_EVENTS.COMMON.CONNECT, () => {

--- a/frontend/src/providers/webSocketProvider.tsx
+++ b/frontend/src/providers/webSocketProvider.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { Socket, io } from 'socket.io-client';
+
+type SocketContextType = {
+  socket: Socket | null;
+};
+
+const initialSocketContext = {
+  socket: null,
+};
+
+const SocketContext = createContext<SocketContextType>(initialSocketContext);
+export const useWebSocket = () => useContext(SocketContext);
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const WebSocketProvider = ({ children }: Props) => {
+  const [socket, setSocket] = useState<Socket | null>(null);
+  useEffect(() => {
+    const socket = io('http://localhost:3001');
+    setSocket(socket);
+
+    socket.on('connect', () => {
+      console.log('socket connected');
+    });
+
+    return () => {
+      socket.disconnect();
+    };
+  }, []);
+
+  return <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>;
+};

--- a/frontend/src/providers/webSocketProvider.tsx
+++ b/frontend/src/providers/webSocketProvider.tsx
@@ -32,5 +32,5 @@ export const WebSocketProvider = ({ children }: Props) => {
     };
   }, []);
 
-  return <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>;
+  return <SocketContext.Provider value={{ socket }}>{children}</SocketContext.Provider>;
 };


### PR DESCRIPTION
<img width="475" alt="スクリーンショット 2024-03-08 030456" src="https://github.com/tmuramat081/42_ft_transcendence/assets/91453112/d76a2259-440f-4f66-bc15-9773a1898f01">

web socketのインスタンスをグローバルで管理するようにしました。
ログイン後の画面では、useWebSocket()を呼び出すことでsocketを呼び出すことが可能です。
ちなみに、接続時は共通ヘッダーにconnectedの表示が出ます。